### PR TITLE
feat: add Zhipu GLM API support

### DIFF
--- a/background.js
+++ b/background.js
@@ -263,6 +263,9 @@ async function handleTLDRRequest(tweetData, articleUrl, quotedTweetUrl) {
     case 'kimi':
       tldr = await callKimi(apiKey, settings.model || 'moonshot-v1-8k', prompt, maxTokens);
       break;
+    case 'zhipu':
+      tldr = await callZhipu(apiKey, settings.model || 'glm-4-flash', prompt, maxTokens);
+      break;
     default:
       throw new Error('不支持的模型: ' + settings.provider);
   }
@@ -555,6 +558,28 @@ async function callKimi(apiKey, model, prompt, maxTokens) {
   if (!res.ok) {
     var err = await res.json().catch(function () { return {}; });
     throw new Error((err.error && err.error.message) || 'Kimi API error: ' + res.status);
+  }
+  var data = await res.json();
+  return data.choices[0].message.content;
+}
+
+async function callZhipu(apiKey, model, prompt, maxTokens) {
+  var res = await fetch('https://open.bigmodel.cn/api/paas/v4/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + apiKey },
+    body: JSON.stringify({
+      model: model,
+      messages: [
+        { role: 'system', content: prompt.system },
+        { role: 'user', content: prompt.user },
+      ],
+      max_tokens: maxTokens,
+      temperature: 0.3,
+    }),
+  });
+  if (!res.ok) {
+    var err = await res.json().catch(function () { return {}; });
+    throw new Error((err.error && err.error.message) || '智谱 API error: ' + res.status);
   }
   var data = await res.json();
   return data.choices[0].message.content;

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "https://twitter.com/*",
     "https://api.openai.com/*",
     "https://api.anthropic.com/*",
-    "https://api.moonshot.cn/*"
+    "https://api.moonshot.cn/*",
+    "https://open.bigmodel.cn/*"
   ],
   "background": {
     "service_worker": "background.js"

--- a/popup.html
+++ b/popup.html
@@ -22,6 +22,7 @@
             <option value="openai">OpenAI (GPT)</option>
             <option value="claude">Claude (Anthropic)</option>
             <option value="kimi">Kimi (月之暗面)</option>
+            <option value="zhipu">智谱 (GLM)</option>
           </select>
         </div>
 

--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,7 @@ const DEFAULT_MODELS = {
   openai: 'gpt-4o-mini',
   claude: 'claude-sonnet-4-20250514',
   kimi: 'moonshot-v1-8k',
+  zhipu: 'glm-4-flash',
 };
 
 // ── Init ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Add support for Zhipu AI's GLM models as a new provider option.

Changes:
- Add https://open.bigmodel.cn/* to host_permissions in manifest.json
- Add callZhipu() function in background.js for API calls
- Add "Zhipu (GLM)" option in provider dropdown
- Set glm-4-flash as the default model for Zhipu provider

The implementation follows the same pattern as existing providers (OpenAI, Claude, Kimi), using the compatible chat completions endpoint format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)